### PR TITLE
Upgraded to Spring Boot 2.0.0.RC1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ public class MyBean {
 }
 ```
 
-The [endpoint](http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html) is reachable via _**http://${yourAddress}/application/failsafe**_.
+The [endpoint](http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html) is 
+reachable via _**http://${yourAddress}/actuator/failsafe**_.
 
 The generated output will look like this:
 

--- a/library/src/main/java/org/zalando/failsafeactuator/endpoint/FailsafeEndpoint.java
+++ b/library/src/main/java/org/zalando/failsafeactuator/endpoint/FailsafeEndpoint.java
@@ -14,7 +14,6 @@ import net.jodah.failsafe.CircuitBreaker;
 
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.zalando.failsafeactuator.endpoint.domain.CircuitBreakerState;
 import org.zalando.failsafeactuator.service.CircuitBreakerRegistry;
 
@@ -29,7 +28,6 @@ import java.util.Map;
  *
  * @author mpickhan on 29.06.16.
  */
-@ConfigurationProperties(prefix = "endpoints.failsafe")
 @Endpoint(id = "failsafe")
 public class FailsafeEndpoint {
   private final CircuitBreakerRegistry circuitBreakerRegistry;

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
 		<java.version>1.8</java.version>
         <maven.deploy.skip>true</maven.deploy.skip>
-		<spring-boot.version>2.0.0.M5</spring-boot.version>
+		<spring-boot.version>2.0.0.RC1</spring-boot.version>
 	</properties>
 
     <modules>

--- a/sample/src/main/java/org/zalando/failsafeactuator/sample/SampleApplicationBanner.java
+++ b/sample/src/main/java/org/zalando/failsafeactuator/sample/SampleApplicationBanner.java
@@ -14,7 +14,7 @@ public class SampleApplicationBanner implements Banner {
         banner += "Failsafe-Actuator sample applicaton is running!\n";
         banner += "\n";
         banner += "See the circuit breaker status:\n";
-        banner += "   $ curl http://127.0.0.1:" + port + "/application/failsafe\n";
+        banner += "   $ curl http://127.0.0.1:" + port + "/actuator/failsafe\n";
         banner += "Unreliable endpoint that fails every second invocation:\n";
         banner += "   $ curl http://127.0.0.1:" + port + "/unreliable\n";
         banner += "Reliable endpoint using a circuit breaker and fallback:\n";

--- a/sample/src/main/resources/application.properties
+++ b/sample/src/main/resources/application.properties
@@ -10,5 +10,4 @@
 #
 server.port=8080
 logging.level.root=WARN
-endpoints.failsafe.enabled=true
-management.security.enabled=false
+management.endpoints.web.expose=failsafe

--- a/sample/src/test/java/org/zalando/failsafeactuator/endpoint/EndpointTest.java
+++ b/sample/src/test/java/org/zalando/failsafeactuator/endpoint/EndpointTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertTrue;
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class EndpointTest {
 
-  private static final String FAILSAFE_URL = "http://localhost:%d/application/failsafe";
+  private static final String FAILSAFE_URL = "http://localhost:%d/actuator/failsafe";
 
   private static final String BREAKER_NAME = "testBreaker";
 


### PR DESCRIPTION
- Actuator endpoint configuration has changed since 2.0.0.M7. The default
management.endpoints.web.base-path has been changed from "/application"
to "/actuator" hence failsafe's default actuator endpoint is updated
accordingly.
- Endpoint exposure has been changed as well in 2.0.0.M7, hence updated
FailsafeEndpoint's configuration to expose the endpoint consistent to
other default actuator endpoints.
- Updated the endpoint URL in the documentation & sample app's banner.
- Updated sample's application.properties per configuration changes.

Ref: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0.0-M7-Release-Notes

Related issue: #43