### PR TITLE
Upgraded to Spring Boot 2.0.0.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,34 +17,13 @@
 		<project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
 		<java.version>1.8</java.version>
         <maven.deploy.skip>true</maven.deploy.skip>
-		<spring-boot.version>2.0.0.RC1</spring-boot.version>
+		<spring-boot.version>2.0.0.RELEASE</spring-boot.version>
 	</properties>
 
     <modules>
         <module>library</module>
         <module>sample</module>
     </modules>
-
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/libs-milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/libs-milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
 
 	<dependencies>
         <dependency>

--- a/sample/src/main/resources/application.properties
+++ b/sample/src/main/resources/application.properties
@@ -10,4 +10,4 @@
 #
 server.port=8080
 logging.level.root=WARN
-management.endpoints.web.expose=failsafe
+management.endpoints.web.exposure.include=failsafe


### PR DESCRIPTION
- Removed milestone repository configuration
- Endpoint exposure configuration has been changed (again) in 2.0.0.RC2/RELEASE,
hence updated sample's application.properties accordingly.

Ref: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0.0-RC2-Release-Notes#configuration-key-harmonization

Related issue: #43, #70